### PR TITLE
Missing end block comment RHSUSFW Categories

### DIFF
--- a/TRADERS/RHSUSFW/TraderCategoriesRHSUSFW.hpp
+++ b/TRADERS/RHSUSFW/TraderCategoriesRHSUSFW.hpp
@@ -509,7 +509,7 @@
 			"rhs_weap_m4a1_grip2",
 			"rhs_weap_mk18_grip2",
 			"rhs_weap_mk18_grip2_KAC"
-
+		*/
 		};
 	};
 


### PR DESCRIPTION
Assume the blank space is where the block comment would end. After having manually created a separated mod list, this block comment list is not correct. Temporary fix until I can finish the split mod lists.