### PR TITLE
Recategorized orca dynamic loadout

### DIFF
--- a/TRADERS/ARMA3V/ItemListARMA3V.hpp
+++ b/TRADERS/ARMA3V/ItemListARMA3V.hpp
@@ -246,7 +246,7 @@
 	class C_Heli_light_01_wasp_F                        { quality = 1; price = 22000; };
 	class C_Heli_light_01_wave_F                        { quality = 1; price = 22000; };
 	class I_Heli_light_03_unarmed_F 					{ quality = 1; price = 22000; };
-	class O_Heli_Light_02_dynamicLoadout_F              { quality = 1; price = 22000; };
+	class O_Heli_Light_02_unarmed_F 					{ quality = 1; price = 22000; };
 	class O_Heli_Transport_04_F							{ quality = 1; price = 40000; };
 	class O_Heli_Transport_04_ammo_F					{ quality = 1; price = 60000; };
 	class O_Heli_Transport_04_ammo_black_F 				{ quality = 1; price = 58000; };
@@ -283,7 +283,7 @@
 	class O_Heli_Attack_02_dynamicLoadout_F				{ quality = 1; price = 160000; };	//new dynamic version
 	class O_Heli_Attack_02_dynamicLoadout_black_F		{ quality = 1; price = 160000; };	//new dynamic version
 	class O_Heli_Light_02_F 							{ quality = 1; price = 110000; };
-	class O_Heli_Light_02_unarmed_F 					{ quality = 1; price = 110000; };
+	class O_Heli_Light_02_dynamicLoadout_F              { quality = 1; price = 110000; };
 	class O_Heli_Light_02_v2_F							{ quality = 1; price = 110000; };
 
 	///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The Orca dynamic loadout is miscategorized as unarmed. O_Heli_Light_02_dynamicLoadout_F is actually armed and should be priced/categorized the same as the armed variants of the orca. The unarmed was listed in the armed category and priced the same as the armed variants.