### PR TITLE
Recategorized orca dynamic loadout

### DIFF
--- a/TRADERS/ARMA3V/TraderCategoriesARMA3V.hpp
+++ b/TRADERS/ARMA3V/TraderCategoriesARMA3V.hpp
@@ -287,7 +287,7 @@
 			"C_Heli_light_01_wasp_F",
 			"C_Heli_light_01_wave_F",
 			"I_Heli_light_03_unarmed_F",
-			"O_Heli_Light_02_dynamicLoadout_F",
+			"O_Heli_Light_02_unarmed_F",
 			"O_Heli_Transport_04_F",
 			"O_Heli_Transport_04_ammo_F",
 			"O_Heli_Transport_04_ammo_black_F",
@@ -329,7 +329,7 @@
 			"O_Heli_Attack_02_dynamicLoadout_F",
 			"O_Heli_Attack_02_dynamicLoadout_black_F",
 			"O_Heli_Light_02_F",
-			"O_Heli_Light_02_unarmed_F",
+			"O_Heli_Light_02_dynamicLoadout_F",
 			"O_Heli_Light_02_v2_F"
 		};
 	};


### PR DESCRIPTION
The Orca dynamic loadout is miscategorized as unarmed. O_Heli_Light_02_dynamicLoadout_F is actually armed and should be priced/categorized the same as the armed variants of the orca. The unarmed was listed in the armed category and priced the same as the armed variants.